### PR TITLE
Connect Settings nav item to settings page

### DIFF
--- a/dark-timeline.php
+++ b/dark-timeline.php
@@ -18,7 +18,7 @@
         </div>
 
         <div class="row">
-            
+
             <div class="col-md-3 d-flex flex-column align-items-center profile-section">
                 <div class="profile-img-wrapper">
                     <img class="profile-img" src="assets/img/profile.png">
@@ -35,12 +35,12 @@
                 </div>
 
                 <div>
-                    
+
                     <ul class="menu-wrapper d-flex flex-column">
                         <a href=""><li class="menu-item text-center">Draft</li></a>
                         <a href="#"><li class="menu-item text-center">My Blogs</li> </a>
                         <a href="#"><li class="menu-item text-center">Insights</li> </a>
-                        <a href="#"><li class="menu-item text-center">Settings</li> </a>
+                        <a href="user-profile-setting.php"><li class="menu-item text-center">Settings</li> </a>
 
                     </ul>
                 </div>
@@ -48,7 +48,7 @@
                 <div class="line"></div>
 
                 <div>
-                    
+
                     <ul class="menu-wrapper d-flex flex-column">
                         <a href="#"><li class="menu-item text-center">English (US)</li> </a>
                         <a href="#"><li class="menu-item text-center">Privacy</li> </a>
@@ -61,7 +61,7 @@
 
             </div>
             <div class="col-md-9">
-                
+
                 <!-- <div class=""> -->
 
                     <div class="row d-flex flex-column post-section">
@@ -83,7 +83,7 @@
                                 <a class="post-action-item" href="#css"><img src="assets/img/link.svg" width="15"></a>
                                 <button class="btn publish-btn post-action-item">Publish</button>
                             </div>
-                            
+
                         </div>
                     </div>
 
@@ -94,7 +94,7 @@
                             <img src="assets/img/caret.svg">
                         </div>
                     </div>
-                    
+
                     <div class="row mx-0 mt-md-4 blog-item-wrapper first-child">
                         <div class="d-flex flex-row px-0 blog-item">
                             <div class="blog-item-author-avatar-wrapper">
@@ -134,7 +134,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -177,7 +177,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -220,7 +220,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -263,7 +263,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -306,7 +306,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
                     <div class="row mx-0 blog-item-wrapper">
@@ -348,7 +348,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
                 <!-- </div> -->
                 <h6 class="text-center" style="margin-top:27px;margin-bottom:27px">Load More<h5>

--- a/timeline.php
+++ b/timeline.php
@@ -21,7 +21,7 @@
         </div>
 
         <div class="row">
-            
+
             <div class="col-md-3 d-flex flex-column align-items-center profile-section">
                 <div class="profile-img-wrapper">
                     <img class="profile-img" src="assets/img/profile.png">
@@ -38,12 +38,12 @@
                 </div>
 
                 <div>
-                    
+
                     <ul class="menu-wrapper d-flex flex-column">
                         <a href=""><li class="menu-item text-center">Draft</li></a>
                         <a href="#"><li class="menu-item text-center">My Blogs</li> </a>
                         <a href="#"><li class="menu-item text-center">Insights</li> </a>
-                        <a href="#"><li class="menu-item text-center">Settings</li> </a>
+                        <a href="user-profile-setting.php"><li class="menu-item text-center">Settings</li> </a>
 
                     </ul>
                 </div>
@@ -51,7 +51,7 @@
                 <div class="line"></div>
 
                 <div>
-                    
+
                     <ul class="menu-wrapper d-flex flex-column">
                         <a href="#"><li class="menu-item text-center">English (US)</li> </a>
                         <a href="#"><li class="menu-item text-center">Privacy</li> </a>
@@ -64,7 +64,7 @@
 
             </div>
             <div class="col-md-9">
-                
+
                 <!-- <div class=""> -->
 
                     <div class="row d-flex flex-column post-section">
@@ -86,7 +86,7 @@
                                 <a class="post-action-item" href="#css"><img src="assets/img/link.svg"></a>
                                 <button class="btn publish-btn post-action-item">Publish</button>
                             </div>
-                            
+
                         </div>
                     </div>
 
@@ -97,7 +97,7 @@
                             <img src="assets/img/caret.svg">
                         </div>
                     </div>
-                    
+
                     <div class="row mx-0 mt-md-4 blog-item-wrapper first-child">
                         <div class="d-flex flex-row px-0 blog-item">
                             <div class="blog-item-author-avatar-wrapper">
@@ -137,7 +137,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -180,7 +180,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -223,7 +223,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -266,7 +266,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
 
@@ -309,7 +309,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
 
                     <div class="row mx-0 blog-item-wrapper">
@@ -351,7 +351,7 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
                 <!-- </div> -->
             </div>


### PR DESCRIPTION

![settings_1](https://user-images.githubusercontent.com/28525986/55721243-b97a3200-59fa-11e9-9cf6-eea28166573e.png)

Previously, the **Settings** tab was a dead link. I have rectified this by changing the `href` attribute to correct path to the `user-profile-setting.php` page. Now, clicking on the link will navigate to the settings page. This has been done in both the `timeline.php` and `dark-timeline.php` files.