### PR TITLE
 Implemented tags retrieval when GET request is pointed to tag

### DIFF
--- a/tags.php
+++ b/tags.php
@@ -1,0 +1,5 @@
+<?php
+// Check if the server request method is, and the request URL is tags
+if($_SERVER['REQUEST_METHOD'] == "GET" && $_SERVER['PHP_SELF'] == "/tags.php"){
+    $tag = isset($_GET['t']) ? $_GET['t'] : null ;
+}

--- a/tags.php
+++ b/tags.php
@@ -1,5 +1,7 @@
 <?php
 // Check if the server request method is, and the request URL is tags
 if($_SERVER['REQUEST_METHOD'] == "GET" && $_SERVER['PHP_SELF'] == "/tags.php"){
-    $tag = isset($_GET['t']) ? $_GET['t'] : null ;
+    $tag = isset($_GET['t']) ? $_GET['t'] : NULL ;
+}else{
+    $tag = NULL;
 }


### PR DESCRIPTION
To get tag request from pointing get request to tags.php e.g tag.php?t="health"...
isset($_GET['t']) would pick up the paramenter and assign to a variable $tag.

The variable will only have a none null value when the URI is /tags.php and the GET parameter 't' is supplied a value
 