### PR TITLE
Add template for pages and their CSS

### DIFF
--- a/assets/css/template.css
+++ b/assets/css/template.css
@@ -1,0 +1,62 @@
+:root {
+  /* the light theme is the default */
+  /* specify colors for the light theme here */
+  /* the syntax is */
+  /* --variable-name: variable value */
+  /* for example */
+  --bg-color: white;
+  --default-text-color: black;
+
+  /* specify other colors you use here */
+  /* ... */
+  /* ... */
+  /* ... */
+  /* they will be reassigned in the dark theme */
+
+  /* these colors do not change with the theme */
+  /* so they will NOT be reassigned in the .dark class */
+  --btn-bg-color: cornflowerblue;
+  --btn-text-color: white;
+
+  /* these variables are for the transition, don't change them */
+  --theme-change-transition-duration: 0.3s;
+  --theme-change-timing-function: ease;
+}
+
+.dark {
+  /* the .dark class will be added to the body element of each page */
+  /* which will ensure that the colors here apply throughout the page */
+  /* specify the new values for the colors that need to change */
+  --bg-color: #06223d;
+  --default-text-color: white;
+  /* ... */
+  /* ... */
+  /* ... */
+
+  /* I haven't reassigned --btn-bg-color and --btn-text-color */
+  /* because they don't change across themes */
+}
+
+html,
+body {
+  /* now use the variable as necessary */
+  /* the syntax is */
+  /* css-property: var(--variable-name); */
+  /* for example */
+  background-color: var(--bg-color);
+  color: var(--default-text-color);
+
+  /* this transition makes the color change smoothly */
+  /* don't change it */
+  transition: background-color var(--theme-change-transition-duration)
+      var(--theme-change-timing-function),
+    color var(--theme-change-transition-duration)
+      var(--theme-change-timing-function);
+
+  height: 100vw;
+}
+
+button {
+  background-color: var(--btn-bg-color);
+  color: var(--btn-text-color);
+}

--- a/template.php
+++ b/template.php
@@ -1,0 +1,32 @@
+<!-- mylo carson 2019-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Blog Task</title>
+    <link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="assets/css/template.css">
+</head>
+<body class="">
+    <div class="container-fluid">
+      <!-- Leave this button here. It will be removed later -->
+      <div><button class="toggle-theme">Click me to toggle theme</button></div>
+
+      <!-- Between this comment line and the one below, add your code -->
+      <h1>Heading</h1>
+      <p>Content</p>
+      <!-- Between this comment line and the one above, add your code -->
+    </div>
+
+    <script>
+    // DON'T REMOVE THE 2 LINES OF CODE BELOW
+    const toggleThemeBtn = document.querySelector('.toggle-theme');
+    toggleThemeBtn.addEventListener('click', e => document.querySelector('body').classList.toggle('dark'));
+    // DON'T REMOVE THE 2 LINES OF CODE ABOVE
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This adds template pages for both PHP and CSS. It clarifies how to use CSS variables to create themes and ensures that the different themes can be easily viewed by clicking on the button. After merging this PR, please ensure to communicate to the frontend group that they should look at these two files and use them to create/refactor their code. They can view the theme change in action by visiting
```localhost:<port>/template.php```

![light-theme](https://user-images.githubusercontent.com/28525986/55783497-72e21180-5aa6-11e9-8edd-d1a6b92c739f.png)
![dark-theme](https://user-images.githubusercontent.com/28525986/55783503-770e2f00-5aa6-11e9-86be-584171861ccb.png)
![php-code](https://user-images.githubusercontent.com/28525986/55783618-bc326100-5aa6-11e9-822c-4a350c13e7f3.png)
![css-code](https://user-images.githubusercontent.com/28525986/55783625-bfc5e800-5aa6-11e9-8de2-42897f069e84.png)
