### PR TITLE
Redirect requests to index.php

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,17 @@
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews -Indexes
+    </IfModule>
+
+    RewriteEngine On
+
+    # Redirect Trailing Slashes If Not A Folder...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} (.+)/$
+    RewriteRule ^ %1 [L,R=301]
+
+    # Handle Front Controller...
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [L]
+</IfModule>

--- a/nginx.config
+++ b/nginx.config
@@ -1,0 +1,9 @@
+if (!-d $request_filename){
+  set $rule_0 1$rule_0;
+}
+if (!-f $request_filename){
+  set $rule_0 2$rule_0;
+}
+if ($rule_0 = "21"){
+  rewrite ^/(.+)$ /index.php last;
+}


### PR DESCRIPTION
**Title**
Redirect requests to `index.php`

**Purpose**
`index.php` will contain the router that then decides which page will be rendered to the user.

**Features**
Redirection has been added using rules in `nginx.config` (for Nginx servers) and `.htaccess` (for Apache servers).

**Testing**
At the end of `index.php`, add
```
echo "Hello World";
```

Then visit `localhost:8000/test-request` and see that "Hello World" is shown on the screen.

![redirection](https://user-images.githubusercontent.com/28525986/56220580-95ed6200-6060-11e9-89b1-4a66850557d9.png)
