### PR TITLE
edited the delete/edit posts popup to be responsive for mobile and ta…

### DIFF
--- a/resources/themes/ghost/templates/drafts.html
+++ b/resources/themes/ghost/templates/drafts.html
@@ -90,10 +90,17 @@
         border-bottom: 1px solid #ebebeb;
     }
 
-    .post-drafts .logo-on-page {
+    .post-drafts .dropdown-menu {
         position: relative;
-        top: -0.5em;
+        margin-top: 2em;
+        margin-left: -2.5em;
     }
+
+    .post-drafts .dropdown-icon {
+        font-size: 30px;
+        margin-left: -30px;
+    }
+
 
     .post-drafts .dropdown-btn-link {
         font-size: 15px;
@@ -116,7 +123,25 @@
             width: 90%;
             border-bottom: 1px solid #ebebeb;
         }
+
+        .post-drafts .dropdown-menu {
+            position: relative;
+            margin-top: 2em;
+            margin-left: -6em;
+        }
+    
     }
+
+    @media screen and (max-width:900px) {
+        .post-drafts .dropdown-menu {
+            position: relative;
+            margin-top: 2em;
+            margin-left: -6em;
+        }
+    
+    }
+
+
 </style>
 
 <div class="container-fluid post-drafts">
@@ -162,7 +187,7 @@
                 </div>
 
                 <div class="dropdown col-2" style="cursor:pointer">
-                    <span class="dropdown-toggle" aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
+                    <span class="dropdown-toggle dropdown-icon " aria-haspopup="true" aria-expanded="false" data-toggle="dropdown">
                     </span>
                     <div class="dropdown-menu">
                         <button class="dropdown-item">Edit post</button>


### PR DESCRIPTION

#### What does this PR do?
* It makes the popup for the edit/delete posts button responsive

#### How should this be manually tested?
* Open the drafts page
* Click on the arrow down
* Test the popup on any screen size

#### Screenshots
![Screenshot_2019-04-21 Drafts](https://user-images.githubusercontent.com/33119163/56476456-98e8b800-648f-11e9-8800-e06809d80419.png)
![Screen Shot 2019-04-21 at 23 43 19](https://user-images.githubusercontent.com/33119163/56476457-99814e80-648f-11e9-8fd2-bd97aa209a05.png)
![Screen Shot 2019-04-21 at 23 43 11](https://user-images.githubusercontent.com/33119163/56476458-99814e80-648f-11e9-9a47-10734ef1f60c.png)
